### PR TITLE
Fixing tiny typo - misspelling of initted in doShow

### DIFF
--- a/app/widgets/nl.fokkezb.pullToRefresh/controllers/widget.js
+++ b/app/widgets/nl.fokkezb.pullToRefresh/controllers/widget.js
@@ -11,7 +11,7 @@ var offset = 0;
 
 function doShow(msg) {
 	
-	if (!innited || pulled) {
+	if (!initted || pulled) {
 		return false;
 	}
 	


### PR DESCRIPTION
I've fixed a typo in the doShow method which was throwing an error and preventing doShow from executing.
