### PR TITLE
Added to check a type at `scrollListener`

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -113,6 +113,10 @@ function refresh() {
 
 function scrollListener(e) {
 
+	if (typeof(e.contentOffset) === 'undefined') {
+		return;
+	}
+
 	if (OS_IOS) {
 
 		if (pulled) {


### PR DESCRIPTION
When we use other scrollable views in `TableView` with `pullToRefresh`, the app throw an error that cannot find `e.contentOffset`.

So I added some lines to check the type of `e.contentOffset` in `scrollListener()` function.
