### PR TITLE
Fix minor errors for i18n value names preserving bc

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -1,9 +1,9 @@
 var args = arguments[0] || {};
 
 var options = {
-	msgPull: L('ptrPull', 'Pull to refresh...'),
-	msgRelease: L('ptrRelease', 'Release to refresh...'),
-	msgUpdating: L('ptrUpating', 'Updating...'),
+	msgPull: L('msgPull', L('ptrPull', 'Pull to refresh...')),
+	msgRelease: L('msgRelease', L('ptrRelease', 'Release to refresh...'),)
+	msgUpdating: L('msgUpdating', L('ptrUpdating', L('ptrUpating', 'Updating...'))),
 	top: 0
 };
 


### PR DESCRIPTION
I know it is quite dirty to make L(...,L(..., '')) but I want to preserve bc
