### PR TITLE
Export show & hide functions

### DIFF
--- a/nl.fokkezb.pullToRefresh/controllers/widget.js
+++ b/nl.fokkezb.pullToRefresh/controllers/widget.js
@@ -62,6 +62,7 @@ function hide() {
     refreshControl.setRefreshing(false);
   }
 }
+exports.hide = hide;
 
 function show() {
 
@@ -72,6 +73,7 @@ function show() {
     refreshControl.setRefreshing(true);
   }
 }
+exports.show = show;
 
 function onRefreshstart() {
 


### PR DESCRIPTION
Exporting the show  & hide functions so you can, from code, show & hide the PTR without having to use the from the callback.