### PR TITLE
add a function to set a title

### DIFF
--- a/nl.fokkezb.pullToRefresh/controllers/widget.js
+++ b/nl.fokkezb.pullToRefresh/controllers/widget.js
@@ -73,6 +73,19 @@ function show() {
   }
 }
 
+function setTitle(text){
+	if (text.apiName && text.apiName == 'Ti.UI.AttributedString'){
+		refreshTitle = text;
+	} else {
+		refreshTitle = Ti.UI.createAttributedString({
+    		text: text
+  		});
+	}
+
+	refreshControl.title = refreshTitle;
+}
+exports.setTitle = setTitle;
+
 function onRefreshstart() {
 
   $.trigger('release', {


### PR DESCRIPTION
the refreshControl has a title property, but this is not used/exposed.

Now it is, with the option to not add an attributed string, but a text instead. The title property only accepts attributed string, so this is detected