### PR TITLE
use unified Ti.UI.createRefreshControl API for iOS & Android

### DIFF
--- a/nl.fokkezb.pullToRefresh/controllers/widget.js
+++ b/nl.fokkezb.pullToRefresh/controllers/widget.js
@@ -1,61 +1,47 @@
 var refreshControl;
-var list;
 
 $.refresh = refresh;
-
-$.show = show;
 $.hide = hide;
-$.getList = getList;
-$.getControl = getControl;
+$.show = show;
+$.setPullText = setPullText;
+
+var args = arguments[0] || {};
+
+if (!_.isArray(args.children) || !_.contains(['Ti.UI.ListView', 'Ti.UI.TableView', 'de.marcelpociot.CollectionView'], args.children[0].apiName)) {
+  console.error('[pullToRefresh] is missing required Ti.UI.ListView or Ti.UI.TableView or de.marcelpociot.CollectionView as first child element.');
+}
+
+var list = args.children[0];
+var refreshText = args.refreshText ? args.refreshText : 'Loading';
+var pullText = args.pullText ? args.pullText : 'Loading';
+
+delete args.children;
+delete args.refreshText;
+delete args.pullText;
 
 (function constructor(args) {
 
-  if (args.dontInit || (!OS_IOS && !OS_ANDROID)){
-    if (!args.dontInit) console.warn('[pullToRefresh] only supports iOS and Android.');
-
-    if (_.isArray(args.children)) {
-      _.map(args.children, $.addTopLevelView);
-    }
-
+  if (!OS_IOS && !OS_ANDROID) {
+    console.warn('[pullToRefresh] only supports iOS and Android.');
     return;
   }
-
-  if (!_.isArray(args.children) || !_.contains(['Titanium.UI.ListView', 'Titanium.UI.TableView', 'Ti.UI.ListView', 'Ti.UI.TableView', 'de.marcelpociot.CollectionView'], args.children[args.children.length-1].apiName)) {
-    console.error('[pullToRefresh] is missing required Ti.UI.ListView or Ti.UI.TableView or de.marcelpociot.CollectionView as first child element.');
-    return;
-  }
-
-  list = _.last(args.children);
-  delete args.children;
 
   _.extend($, args);
 
-  if (OS_IOS) {
-    refreshControl = Ti.UI.createRefreshControl(args);
+    refreshControl = Ti.UI.createRefreshControl({
+      title: createText(pullText, '#FFF'),
+      tintColor: '#ededeb'
+    });
+
     refreshControl.addEventListener('refreshstart', onRefreshstart);
 
     list.refreshControl = refreshControl;
 
     $.addTopLevelView(list);
 
-  } else if (OS_ANDROID) {
-    refreshControl = require('com.rkam.swiperefreshlayout').createSwipeRefresh(_.extend({
-      view: list
-    }, args));
-
-    refreshControl.addEventListener('refreshing', onRefreshstart);
-
-    $.addTopLevelView(refreshControl);
-  }
-
-})(arguments[0] || {});
+})(args);
 
 function refresh() {
-
-  if (!list) {
-    return;
-  }
-
   show();
 
   onRefreshstart();
@@ -63,45 +49,38 @@ function refresh() {
 
 function hide() {
 
-  if (!refreshControl) {
-    return;
-  }
-
-  if (OS_IOS) {
+    refreshControl.title = createText(pullText, '#FFF');
     refreshControl.endRefreshing();
 
-  } else if (OS_ANDROID) {
-    refreshControl.setRefreshing(false);
-  }
 }
 
 function show() {
-
-  if (!refreshControl) {
-    return;
-  }
-
-  if (OS_IOS) {
     refreshControl.beginRefreshing();
-
-  } else if (OS_ANDROID) {
-    refreshControl.setRefreshing(true);
-  }
-}
-
-function getList() {
-  return list;
-}
-
-function getControl() {
-  return refreshControl;
 }
 
 function onRefreshstart() {
+    refreshControl.title = createText(refreshText, '#FFF');
 
   $.trigger('release', {
     source: $,
     hide: hide
   });
 
+}
+
+function createText(text, color) {
+  return Ti.UI.createAttributedString({
+    text: text,
+    attributes: [
+      {
+        type: Ti.UI.ATTRIBUTE_FOREGROUND_COLOR ,
+        value: color,
+        range: [0, text.length]
+      }
+    ]
+  });
+}
+
+function setPullText(text) {
+  pullText = text;
 }

--- a/nl.fokkezb.pullToRefresh/widget.json
+++ b/nl.fokkezb.pullToRefresh/widget.json
@@ -3,11 +3,11 @@
 	"name": "Pull to Refresh Widget",
 	"description" : "Uniform wrapper for iOS RefreshControl and Android SwipeRefreshLayout.",
 	"author": "Fokke Zandbergen",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"copyright":"Copyright (c) 2013-2015",
 	"license":"Apache 2.0",
 	"min-alloy-version": "1.5",
-	"min-titanium-version":"3.4",
+	"min-titanium-version":"6.2",
 	"tags":"tableview,headerpullview,pulltorefresh,swiperefreshlayout,listview,pullview,refreshcontrol,ticollectionview",
 	"platforms":"ios,android",
 	"modules": {


### PR DESCRIPTION
I just removed the `if(OS_IOS)` and `if(OS_ANDROID)`  tests and Android specific code because since [this change](https://jira.appcelerator.org/browse/TIMOB-1072), we can now use `Ti.UI.createRefreshControl` on both platform 

See `6.2.0.GA` [changelog](http://docs.appcelerator.com/platform/latest/#!/guide/Titanium_SDK_6.2.0.GA_Release_Note) 

of course I invite you to test this, since I just made the fix and am testing this on my app, working fine so far